### PR TITLE
refacto(modernize): PHP 8.5+, Symfony 8, PHPStan max, bug fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ phpunit: vendor
 	$(RUN) vendor/bin/phpunit
 
 phpstan: vendor
-	$(RUN) vendor/bin/phpstan analyse -c phpstan.neon --level=9 src/
+	$(RUN) vendor/bin/phpstan analyse -c phpstan.neon --level=max src/
 
 cs: vendor
 	$(RUN) vendor/bin/php-cs-fixer fix --dry-run --diff --verbose

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   php:
     build: ./dist/docker

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,9 @@
   ],
   "license": "MIT",
   "require": {
-    "php": ">=8.2",
-    "symfony/process": "^7.0",
-    "symfony/serializer": "^7.0"
+    "php": ">=8.5",
+    "symfony/process": "^8.0",
+    "symfony/serializer": "^8.0"
   },
   "autoload": {
     "psr-4": {
@@ -19,9 +19,9 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^10.0",
-    "phpstan/phpstan": "^1.2",
+    "phpunit/phpunit": "^13.0",
+    "phpstan/phpstan": "^2.0",
     "friendsofphp/php-cs-fixer": "^3.0",
-    "symfony/var-dumper": "^7.0"
+    "symfony/var-dumper": "^8.0"
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,2 @@
 parameters:
     ignoreErrors:
-    checkMissingIterableValueType: false

--- a/src/ExifTool.php
+++ b/src/ExifTool.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Jmoati\ExifTool;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -23,7 +22,7 @@ final readonly class ExifTool
         $process = new Process(['which', 'exiftool']);
         $process->run();
 
-        if ($process->getExitCode() > Command::SUCCESS) {
+        if ($process->getExitCode() > 0) {
             throw new ExecutableCannotBeFoundException();
         }
 

--- a/src/Media.php
+++ b/src/Media.php
@@ -6,11 +6,14 @@ namespace Jmoati\ExifTool;
 
 final readonly class Media
 {
+    /**
+     * @param array<string, array<string, mixed>> $data
+     */
     public function __construct(
         public array $data,
         public ?\DateTimeImmutable $date,
         public ?MediaGps $gps,
-        public string $mimetype
+        public string $mimetype,
     ) {
     }
 }

--- a/src/MediaDateDenormalizer.php
+++ b/src/MediaDateDenormalizer.php
@@ -8,19 +8,19 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class MediaDateDenormalizer implements DenormalizerInterface
 {
-    public const TYPE = 'MediaDate';
+    public const string TYPE = 'MediaDate';
 
     public function denormalize(
         mixed $data,
         string $type,
-        string $format = null,
-        array $context = []
+        ?string $format = null,
+        array $context = [],
     ): ?\DateTimeImmutable {
         assert(is_array($data));
-
+        /** @var array<string, array<string, mixed>> $data */
         foreach ($data as $datum) {
             foreach (['DateTimeOriginal', 'CreationDate', 'DateCreated'] as $key) {
-                if (isset($datum[$key])) {
+                if (isset($datum[$key]) && is_string($datum[$key])) {
                     try {
                         $now = new \DateTimeImmutable();
                         $date = new \DateTimeImmutable($datum[$key]);
@@ -31,7 +31,7 @@ final class MediaDateDenormalizer implements DenormalizerInterface
                                 return $date;
                             }
                         }
-                    } catch (\Exception $e) {
+                    } catch (\ValueError|\Exception) {
                     }
                 }
             }
@@ -40,7 +40,7 @@ final class MediaDateDenormalizer implements DenormalizerInterface
         return null;
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return is_array($data)
             && self::TYPE === $type;
@@ -49,7 +49,7 @@ final class MediaDateDenormalizer implements DenormalizerInterface
     public function getSupportedTypes(?string $format): array
     {
         return [
-          self::TYPE => true,
+            self::TYPE => true,
         ];
     }
 }

--- a/src/MediaDenormalizer.php
+++ b/src/MediaDenormalizer.php
@@ -12,10 +12,10 @@ final class MediaDenormalizer implements DenormalizerInterface, DenormalizerAwar
 {
     use DenormalizerAwareTrait;
 
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): Media
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): Media
     {
         assert(is_array($data));
-
+        /** @var array<string, array<string, mixed>> $data */
         unset(
             $data['SourceFile'],
             $data['ExifTool'],
@@ -44,7 +44,7 @@ final class MediaDenormalizer implements DenormalizerInterface, DenormalizerAwar
         );
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return is_array($data)
             && Media::class === $type;

--- a/src/MediaGpsDenormalizer.php
+++ b/src/MediaGpsDenormalizer.php
@@ -8,41 +8,45 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class MediaGpsDenormalizer implements DenormalizerInterface
 {
-    public const LATITUDE_KEY = 'GPSLatitude';
-    private const LONGITUDE_KEY = 'GPSLongitude';
-    private const ALTITUDE_KEY = 'GPSAltitude';
-    private const DATETIME_KEY = 'GPSDateTime';
+    public const string LATITUDE_KEY = 'GPSLatitude';
+    private const string LONGITUDE_KEY = 'GPSLongitude';
+    private const string ALTITUDE_KEY = 'GPSAltitude';
+    private const string DATETIME_KEY = 'GPSDateTime';
 
     public function denormalize(
         mixed $data,
         string $type,
-        string $format = null,
-        array $context = []
+        ?string $format = null,
+        array $context = [],
     ): ?MediaGps {
         assert(is_array($data));
-
+        /** @var array<string, array<string, mixed>> $data */
         $latitude = null;
         $longitude = null;
         $datetime = null;
         $altitude = null;
 
         foreach ($data as $datum) {
-            if (isset($datum[self::LATITUDE_KEY])) {
+            if (isset($datum[self::LATITUDE_KEY]) && is_numeric($datum[self::LATITUDE_KEY])) {
                 $latitude = (float) $datum[self::LATITUDE_KEY];
             }
 
-            if (isset($datum[self::LONGITUDE_KEY])) {
+            if (isset($datum[self::LONGITUDE_KEY]) && is_numeric($datum[self::LONGITUDE_KEY])) {
                 $longitude = (float) $datum[self::LONGITUDE_KEY];
             }
 
-            if (isset($datum[self::DATETIME_KEY])) {
-                $datetime = (string) $datum[self::DATETIME_KEY];
+            if (isset($datum[self::DATETIME_KEY]) && is_string($datum[self::DATETIME_KEY])) {
+                $datetime = $datum[self::DATETIME_KEY];
             }
 
-            if (isset($datum[self::ALTITUDE_KEY])) {
-                preg_match('([0-9]+\.?[0-9]*)', $datum[self::ALTITUDE_KEY], $value);
-                $altitude = (float) $value[0];
+            if (isset($datum[self::ALTITUDE_KEY]) && is_string($datum[self::ALTITUDE_KEY])) {
+                preg_match('/(\d+\.?\d*)/', $datum[self::ALTITUDE_KEY], $value);
+                $altitude = isset($value[1]) ? (float) $value[1] : null;
             }
+        }
+
+        if (null === $latitude && null === $longitude && null === $datetime && null === $altitude) {
+            return null;
         }
 
         return new MediaGps(
@@ -53,7 +57,7 @@ final class MediaGpsDenormalizer implements DenormalizerInterface
         );
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return is_array($data)
             && MediaGps::class === $type;

--- a/src/MediaMimeTypeDenormalizer.php
+++ b/src/MediaMimeTypeDenormalizer.php
@@ -8,24 +8,22 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class MediaMimeTypeDenormalizer implements DenormalizerInterface
 {
-    public const TYPE = 'MediaMimeType';
+    public const string TYPE = 'MediaMimeType';
 
     public function denormalize(
         mixed $data,
         string $type,
-        string $format = null,
-        array $context = []
+        ?string $format = null,
+        array $context = [],
     ): string {
         assert(is_array($data));
+        /** @var array<string, array<string, mixed>> $data */
+        $mimeType = $data['File']['MIMEType'] ?? null;
 
-        if (!array_key_exists('MIMEType', $data['File'])) {
-            return 'application/octet-stream';
-        }
-
-        return $data['File']['MIMEType'];
+        return is_string($mimeType) ? $mimeType : 'application/octet-stream';
     }
 
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return is_array($data)
             && self::TYPE === $type;


### PR DESCRIPTION
- Bump PHP requirement to >=8.5, Symfony ^8.0, PHPUnit ^13.0
- PHPStan upgraded to ^2.0 at max level
- Fix ?string $format = null signature on all denormalizers
- Fix MediaGpsDenormalizer returning null when no GPS data found
- Fix altitude regex with proper PCRE delimiters
- Fix MediaMimeTypeDenormalizer safe access on missing File key
- Fix MediaDateDenormalizer empty catch variable removed
- Remove implicit symfony/console dependency (Command::SUCCESS → 0)
- Add typed constants (PHP 8.3 const string)
- Add array<string, array<string, mixed>> PHPDoc for PHPStan 2.x
- Rename docker-compose.yaml to compose.yaml
- PHPStan config: remove deprecated checkMissingIterableValueType