### PR TITLE
perf: reduce memory allocations and redundant work

### DIFF
--- a/src/ExifTool.php
+++ b/src/ExifTool.php
@@ -11,34 +11,39 @@ use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
 
-final readonly class ExifTool
+final class ExifTool
 {
-    private string $exiftoolFile;
+    private static ?string $cachedExiftoolFile = null;
 
-    private SerializerInterface $serializer;
+    private static ?SerializerInterface $cachedSerializer = null;
 
     public function __construct()
     {
-        $process = new Process(['which', 'exiftool']);
-        $process->run();
+        if (null === self::$cachedExiftoolFile) {
+            $process = new Process(['which', 'exiftool']);
+            $process->run();
 
-        if ($process->getExitCode() > 0) {
-            throw new ExecutableCannotBeFoundException();
+            if ($process->getExitCode() > 0) {
+                throw new ExecutableCannotBeFoundException();
+            }
+
+            self::$cachedExiftoolFile = trim($process->getOutput());
         }
 
-        $this->exiftoolFile = str_replace(\PHP_EOL, '', $process->getOutput());
-        $this->serializer = new Serializer(
-            [
-                new MediaDenormalizer(),
-                new MediaDateDenormalizer(),
-                new MediaGpsDenormalizer(),
-                new MediaMimeTypeDenormalizer(),
-                new ArrayDenormalizer(),
-            ],
-            [
-                new JsonDecode([JsonDecode::ASSOCIATIVE => true]),
-            ]
-        );
+        if (null === self::$cachedSerializer) {
+            self::$cachedSerializer = new Serializer(
+                [
+                    new MediaDenormalizer(),
+                    new MediaDateDenormalizer(),
+                    new MediaGpsDenormalizer(),
+                    new MediaMimeTypeDenormalizer(),
+                    new ArrayDenormalizer(),
+                ],
+                [
+                    new JsonDecode([JsonDecode::ASSOCIATIVE => true]),
+                ]
+            );
+        }
     }
 
     public static function openFile(string $filename): Media
@@ -49,8 +54,8 @@ final readonly class ExifTool
     public function media(string $filename): Media
     {
         $command = match ($this->guessScheme($filename)) {
-            'http', 'https' => 'curl -s "$filename" | '.$this->exiftoolFile.' -charset UTF-8 -filesize# -all -c %+.6f -q -j -g -fast -',
-            default => $this->exiftoolFile.' -charset UTF-8 -filesize# -all -c %+.6f -q -j -g -fast "$filename"',
+            'http', 'https' => 'curl -s "$filename" | '.self::$cachedExiftoolFile.' -charset UTF-8 -filesize# -all -c %+.6f -q -j -g -fast -',
+            default => self::$cachedExiftoolFile.' -charset UTF-8 -filesize# -all -c %+.6f -q -j -g -fast "$filename"',
         };
 
         $process = Process::fromShellCommandline(
@@ -67,7 +72,7 @@ final readonly class ExifTool
         }
 
         /** @var Media[] $medias */
-        $medias = $this->serializer->deserialize(
+        $medias = self::$cachedSerializer->deserialize(
             data: $process->getOutput(),
             type: sprintf('%s[]', Media::class),
             format: JsonEncoder::FORMAT

--- a/src/MediaDateDenormalizer.php
+++ b/src/MediaDateDenormalizer.php
@@ -18,18 +18,15 @@ final class MediaDateDenormalizer implements DenormalizerInterface
     ): ?\DateTimeImmutable {
         assert(is_array($data));
         /** @var array<string, array<string, mixed>> $data */
+        $now = new \DateTimeImmutable();
         foreach ($data as $datum) {
             foreach (['DateTimeOriginal', 'CreationDate', 'DateCreated'] as $key) {
                 if (isset($datum[$key]) && is_string($datum[$key])) {
                     try {
-                        $now = new \DateTimeImmutable();
                         $date = new \DateTimeImmutable($datum[$key]);
-                        $string = $date->format('Y-m-d H:i');
 
-                        if (preg_match('/^[0-9]{4}-[0-9]{2}-[0-9]{2}\s[0-9]{2}:[0-9]{2}$/', $string)) {
-                            if ($string !== $now->format('Y-m-d H:i')) {
-                                return $date;
-                            }
+                        if ($date->format('Y-m-d H:i') !== $now->format('Y-m-d H:i')) {
+                            return $date;
                         }
                     } catch (\ValueError|\Exception) {
                     }

--- a/src/MediaGpsDenormalizer.php
+++ b/src/MediaGpsDenormalizer.php
@@ -40,8 +40,11 @@ final class MediaGpsDenormalizer implements DenormalizerInterface
             }
 
             if (isset($datum[self::ALTITUDE_KEY]) && is_string($datum[self::ALTITUDE_KEY])) {
-                preg_match('/(\d+\.?\d*)/', $datum[self::ALTITUDE_KEY], $value);
-                $altitude = isset($value[1]) ? (float) $value[1] : null;
+                $altitude = (float) $datum[self::ALTITUDE_KEY] ?: null;
+            }
+
+            if (null !== $latitude && null !== $longitude && null !== $datetime && null !== $altitude) {
+                break;
             }
         }
 


### PR DESCRIPTION
- Cache exiftool binary path and Serializer statically so openFile() avoids spawning a subprocess and allocating objects on every call
- Remove redundant instance properties that duplicated the static cache; access statics directly in media() instead
- Replace str_replace(PHP_EOL) with trim() for path normalization
- Move DateTimeImmutable() outside nested loops in MediaDateDenormalizer
- Drop redundant regex in MediaDateDenormalizer (format() output always matches the pattern; the comparison with \$now is sufficient)
- Replace preg_match for altitude parsing with a (float) cast; PHP extracts the leading numeric part automatically (e.g. "100.5 m Above Sea Level" → 100.5)
- Add early break in MediaGpsDenormalizer once all four GPS values found